### PR TITLE
readNextPackageChangeSet: handle 'Requested-By' tag

### DIFF
--- a/apt_history/apt_history.py
+++ b/apt_history/apt_history.py
@@ -158,6 +158,8 @@ def readNextPackageChangeSet(lines):
                     packageChanges.extend(parseUpgradedPackages((line[8:]).lstrip()))
                 elif line.startswith('Remove:'):
                     packageChanges.extend(parseRemovedPackages((line[7:]).lstrip()))
+                elif line.startswith('Requested-By:'):
+                    pass
                 else:
                     raise Exception('Invalid line: %s' % line)
         except StopIteration:


### PR DESCRIPTION
Fixes this error:

    Traceback (most recent call last):
      File "/usr/local/bin/apt-history", line 8, in <module>
        sys.exit(main())
      File "/usr/local/lib/python3.10/dist-packages/apt_history/__init__.py", line 22, in main
        packageChangeSet = apt_history.readNextPackageChangeSet(lines)
      File "/usr/local/lib/python3.10/dist-packages/apt_history/apt_history.py", line 162, in readNextPackageChangeSet
        raise Exception('Invalid line: %s' % line)
    Exception: Invalid line: Requested-By: badp (1000)

These lines were added by this commit:
  https://github.com/Debian/apt/commit/46e88ba252230858abe891d5815fce884d3cf35d

These annotations can probably be safely ignored by the program.

~~

Github took the liberty to "fix" the "missing" newline at the end of the program for me. Apologies!